### PR TITLE
Add test for invalid coordinates

### DIFF
--- a/index.js
+++ b/index.js
@@ -432,6 +432,28 @@ function runner(opts) {
                 });
             }
 
+            t.test('Create Data: Should not allow invalid geojson coordinates', (q) => {
+                let invalidCoords = [ 938.832710598893414, -199.38005089759827 ];
+                request.post({
+                    url: 'http://ingalls:yeaheh@localhost:8000/api/data/features',
+                    json: true,
+                    body: {
+                        "type": "FeatureCollection",
+                        "message": "Seneca Picnic Sites",
+                        "features": [{
+                            "type": "Feature",
+                            "action": "create",
+                            "properties": { "building": true },
+                            "geometry": { type: "Point", coordinates: invalidCoords }
+                        }]
+                    }
+                }, (err, res) => {
+                    q.notOk(err);
+                    q.notEqual(res.statusCode, 200);
+                    q.end();
+                });
+            });
+
             t.end();
         });
     });


### PR DESCRIPTION
This adds a failing test because Hecate allows invalid/improbable geo coordinates, though, as I note in the commit message:

```
This one I'm still kind of on the fence on.
Should invalid coords be allowed? IDK.
Maybe people have weird maps.
Or maybe people should not have weird maps.
```

Will open an issue on Hecate for further consideration.
